### PR TITLE
Only start one finisher pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Update makefiles to version 7.2.0
+- Update `ces-build-lib` to 1.62.0
 
 ## [v0.11.0] - 2023-01-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#36] Fixed an issue where the finisher cronjob starts infinite jobs if the pod e.g. can't pull an image.
+
 ### Changed
 - Update makefiles to version 7.2.0
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/cloudogu/ces-build-lib@1.61.0')
+@Library('github.com/cloudogu/ces-build-lib@1.62.0')
 import com.cloudogu.ces.cesbuildlib.*
 
 // Creating necessary git objects, object cannot be named 'git' as this conflicts with the method named 'git' from the library

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!groovy
-@Library(['github.com/cloudogu/dogu-build-lib@v1.6.0', 'github.com/cloudogu/ces-build-lib@1.61.0'])
+@Library('github.com/cloudogu/ces-build-lib@1.61.0')
 import com.cloudogu.ces.cesbuildlib.*
-import com.cloudogu.ces.dogubuildlib.*
 
 // Creating necessary git objects, object cannot be named 'git' as this conflicts with the method named 'git' from the library
 gitWrapper = new Git(this, "cesmarvin")
@@ -43,6 +42,11 @@ node('docker') {
 
         stage("Lint - k8s Resources") {
             stageLintK8SResources()
+        }
+
+        stage('Check Markdown Links') {
+            Markdown markdown = new Markdown(this)
+            markdown.check()
         }
 
         docker

--- a/build/make/bats/Dockerfile
+++ b/build/make/bats/Dockerfile
@@ -1,0 +1,7 @@
+ARG BATS_BASE_IMAGE
+ARG BATS_TAG
+
+FROM ${BATS_BASE_IMAGE}:${BATS_TAG}
+
+# Make bash more findable by scripts and tests
+RUN apk add make git bash

--- a/build/make/bats/customBatsEntrypoint.sh
+++ b/build/make/bats/customBatsEntrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+"$@"

--- a/docs/development/developers_guide_de.md
+++ b/docs/development/developers_guide_de.md
@@ -9,6 +9,7 @@ Zuerst sollten Entwicklungsdateien angelegt werden, die anstelle der Cluster-Wer
 Dogu-Operator-Resource:
 - eine passende YAML-Datei (z. B. `dev-dogu-operator.yaml`) unter `k8s/dev-resources/` ablegen
 - `make serve-local-yaml` liefert alle Ressourcen in dem Verzeichnis aus
+<!-- markdown-link-check-disable-next-line -->
   - Test: [http://localhost:9876/](http://localhost:9876/)
   - ein DNS-/Host-Alias ist hilfreich, um vom lokalen K8s-Cluster mit diesem HTTP-Server zu kommunizieren 
   - das Target benötigt Python3
@@ -16,6 +17,7 @@ Dogu-Operator-Resource:
 `k8s/dev-config/k8s-ces-setup.yaml`:
 - `namespace` legt fest, in welchem Namespace das Cloudogu EcoSystem installiert werden soll
 - `dogu_operator_url` legt die Dogu-Operator-Resource fest
+  <!-- markdown-link-check-disable-next-line -->
   - z. B. `http://192.168.56.1:9876/dev-dogu-operator.yaml` (siehe oben)
 
 ### Ausführung mit `go run` oder einer IDE

--- a/docs/development/developers_guide_en.md
+++ b/docs/development/developers_guide_en.md
@@ -17,6 +17,7 @@ Dogu-operator-resource:
 `k8s/dev-config/k8s-ces-setup.yaml`:
 - `namespace` specifies in which namespace the Cloudogu EcoSystem should be installed
 - `dogu_operator_url` specifies the Dogu operator resource
+   <!-- markdown-link-check-disable-next-line -->
    - e.g. `http://192.168.56.1:9876/dev-dogu-operator.yaml` (see above)
 
 ### execution with `go run` or an IDE

--- a/docs/operations/custom_setup_configuration_de.md
+++ b/docs/operations/custom_setup_configuration_de.md
@@ -24,7 +24,7 @@ Für ein komplett automatisches Setup müssen alle notwendigen Regionen in der `
 Eine komplette Beschreibung der einzelnen Regionen und ihrer Konfigurationswerte folgt in einem späteren Kapitel. 
 
 ## Unterschiede zum herkömmlichen `ces-setup`
-
+<!-- markdown-link-check-disable-next-line -->
 Das `k8s-ces-setup` unterscheidet sich zum [ces-setup](https://github.com/cloudogu/ces-setup) dabei, dass ein EcoSystem nicht auf einer einzelnen VM läuft, sondern innerhalb eines Kubernetes-Cluster auf mehreren VMs.
 Eine `setup.json` von dem `ces-setup` kann ohne Probleme als Setup Konfiguration für das `k8s-ces-setup` benutzt werden.
 

--- a/docs/operations/custom_setup_configuration_en.md
+++ b/docs/operations/custom_setup_configuration_en.md
@@ -23,7 +23,7 @@ For a completely automatic setup all necessary regions must be defined in the `s
 A complete description of the individual regions and their configuration values follows in a later chapter.
 
 ## Differences to conventional `ces-setup`
-
+<!-- markdown-link-check-disable-next-line -->
 The `k8s-ces-setup` differs from the [ces-setup](https://github.com/cloudogu/ces-setup) in that an EcoSystem does not run on a single VM, but within a Kubernetes cluster on multiple VMs.
 A `setup.json` from the `ces-setup` can be used as setup configuration for the `k8s-ces-setup` without any problems.
 

--- a/k8s/k8s-ces-setup.yaml
+++ b/k8s/k8s-ces-setup.yaml
@@ -173,10 +173,14 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: k8s-ces-setup-finisher
+  labels:
+    app: k8s-ces-setup-finisher
+    app.kubernetes.io/name: k8s-ces-setup-finisher
 spec:
   schedule: "* * * * *"
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:
@@ -203,8 +207,45 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: k8s-ces-setup-cleanup-script
+  labels:
+    app: k8s-ces-setup-finisher
+    app.kubernetes.io/name: k8s-ces-setup-finisher
 data:
-  entrypoint.sh: "#!/bin/bash\nSTATE=$(kubectl get configmap k8s-setup-config -o jsonpath='{.data.state}');\nif [[ ${STATE} == \"installed\" ]]; then \n  kubectl delete configmap k8s-ces-setup-json || true\n  kubectl delete configmap k8s-setup-config || true\n  kubectl delete deployments,services,configmaps,secrets,roles,rolebindings,serviceaccounts -l app.kubernetes.io/name=k8s-ces-setup || true\n  kubectl patch cronjob cleanup -p '{\"spec\" : {\"suspend\" : true }}'\n  kubectl delete configmap k8s-ces-setup-cleanup-script\n  kubectl delete cronjob k8s-ces-setup-finisher\n  kubectl delete serviceaccount k8s-ces-setup-finisher\n  kubectl delete rolebinding k8s-ces-setup-finisher\nelse \n  echo \"setup seems not to be installed or successfully executed\";\nfi"
+  entrypoint.sh: "#!/bin/bash\nSTATE=$(kubectl get configmap k8s-setup-config -o jsonpath='{.data.state}');\nif [[ ${STATE} == \"installed\" ]]; then \n  kubectl delete configmap k8s-ces-setup-json || true\n  kubectl delete configmap k8s-setup-config || true\n  kubectl delete deployments,services,configmaps,secrets,roles,rolebindings,clusterroles,clusterrolebindings,serviceaccounts -l app.kubernetes.io/name=k8s-ces-setup || true\n  kubectl patch cronjob cleanup -p '{\"spec\" : {\"suspend\" : true }}'\n  kubectl delete configmap k8s-ces-setup-cleanup-script\n  kubectl delete cronjob k8s-ces-setup-finisher\n  kubectl delete serviceaccount k8s-ces-setup-finisher\n  kubectl delete rolebinding k8s-ces-setup-finisher\nelse \n  echo \"setup seems not to be installed or successfully executed\";\nfi"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-ces-setup-finisher
+  labels:
+    app: k8s-ces-setup-finisher
+    app.kubernetes.io/name: k8s-ces-setup-finisher
+rules:
+  - apiGroups:
+      - "*"
+    resources:
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - delete
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-ces-setup-finisher
+  labels:
+    app: ces
+    app.kubernetes.io/name: k8s-ces-setup-finisher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-ces-setup-finisher
+subjects:
+  - kind: ServiceAccount
+    name: k8s-ces-setup-finisher
+    namespace: '{{ .Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -223,6 +264,8 @@ rules:
       - deployments
       - roles
       - rolebindings
+      - clusterroles
+      - clusterrolebindings
       - serviceaccounts
       - cronjobs
     verbs:


### PR DESCRIPTION
Add `concurrencyPolicy: Forbid` to the job template for the setup finisher to ensure that always one pod ist started. Otherwise, e.g. if an image pull error occurs the cron job would start infinite jobs.