### PR TITLE
#97 create config before components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#97] create config before components
 
 ## [v2.0.0] - 2024-08-02
 **Breaking Change ahead**

--- a/app/setup/starter.go
+++ b/app/setup/starter.go
@@ -32,12 +32,12 @@ type SetupExecutor interface {
 // Starter is used to init and start the setup process
 type Starter struct {
 	globalConfigRepo *k8sreg.GlobalConfigRepository
-	doguConfigRepo    *k8sreg.DoguConfigRepository
-	ClientSet      kubernetes.Interface
-	ClusterConfig  *rest.Config
-	SetupContext   *appcontext.SetupContext
-	Namespace      string
-	SetupExecutor  SetupExecutor
+	doguConfigRepo   *k8sreg.DoguConfigRepository
+	ClientSet        kubernetes.Interface
+	ClusterConfig    *rest.Config
+	SetupContext     *appcontext.SetupContext
+	Namespace        string
+	SetupExecutor    SetupExecutor
 }
 
 // NewStarter creates a new setup starter struct which one inits registries and starts the setup process
@@ -111,14 +111,14 @@ func registerSteps(setupExecutor SetupExecutor, globalConfig *k8sreg.GlobalConfi
 		return fmt.Errorf("failed to register validation setup steps: %w", err)
 	}
 
-	err = setupExecutor.RegisterComponentSetupSteps()
-	if err != nil {
-		return fmt.Errorf("failed to register component setup steps: %w", err)
-	}
-
 	err = setupExecutor.RegisterDataSetupSteps(globalConfig, doguConfig)
 	if err != nil {
 		return fmt.Errorf("failed to register data setup steps: %w", err)
+	}
+
+	err = setupExecutor.RegisterComponentSetupSteps()
+	if err != nil {
+		return fmt.Errorf("failed to register component setup steps: %w", err)
 	}
 
 	err = setupExecutor.RegisterDoguInstallationSteps()

--- a/app/setup/starter_test.go
+++ b/app/setup/starter_test.go
@@ -149,6 +149,7 @@ func TestStarter_StartSetup(t *testing.T) {
 		expect.RegisterLoadBalancerFQDNRetrieverSteps().Return(nil)
 		expect.RegisterSSLGenerationStep().Return(nil)
 		expect.RegisterValidationStep().Return(nil)
+		expect.RegisterDataSetupSteps(mock.Anything, mock.Anything).Return(nil)
 		expect.RegisterComponentSetupSteps().Return(assert.AnError)
 		starter.SetupExecutor = executorMock
 
@@ -167,7 +168,6 @@ func TestStarter_StartSetup(t *testing.T) {
 		expect.RegisterLoadBalancerFQDNRetrieverSteps().Return(nil)
 		expect.RegisterSSLGenerationStep().Return(nil)
 		expect.RegisterValidationStep().Return(nil)
-		expect.RegisterComponentSetupSteps().Return(nil)
 		expect.RegisterDataSetupSteps(mock.Anything, mock.Anything).Return(assert.AnError)
 		starter.SetupExecutor = executorMock
 

--- a/app/setup/starter_test.go
+++ b/app/setup/starter_test.go
@@ -47,8 +47,8 @@ func TestStarter_StartSetup(t *testing.T) {
 		expect.RegisterLoadBalancerFQDNRetrieverSteps().Return(nil)
 		expect.RegisterSSLGenerationStep().Return(nil)
 		expect.RegisterValidationStep().Return(nil)
-		expect.RegisterComponentSetupSteps().Return(nil)
 		expect.RegisterDataSetupSteps(mock.Anything, mock.Anything).Return(nil)
+		expect.RegisterComponentSetupSteps().Return(nil)
 		expect.RegisterDoguInstallationSteps().Return(nil)
 		expect.PerformSetup(testCtx).Return(nil, "")
 		starter.SetupExecutor = executorMock


### PR DESCRIPTION
The k8s-dogu-oparator starts a watch the global-config on startup, but stopps with an error if this config does not exist. Therefore, the config should be created before creating the components (like k8s-dogu-operator)

closes #97 