### PR TITLE
Handle previously created loadbalancer service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#134] The setup can now be processed with a previously created loadbalancer service.
+This is useful if the loadbalancer ip is required for the setup configuration.
+In this case one can simply create the service before, wait for the ip assignment and use it for the setup.
+The setup will patch the service with the default http ports.
 
 ## [v3.3.1] - 2025-01-30
 ### Fixed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('github.com/cloudogu/ces-build-lib@3.1.0')
+@Library('github.com/cloudogu/ces-build-lib@4.0.1')
 import com.cloudogu.ces.cesbuildlib.*
 
 // Creating necessary git objects, object cannot be named 'git' as this conflicts with the method named 'git' from the library

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,11 +43,11 @@ node('docker') {
             make 'dist-clean'
         }
 
-        stage('Lint - Dockerfile') {
+        stage('Lint Dockerfile') {
             lintDockerfile()
         }
 
-        stage('Check Markdown Links') {
+        stage('Check Markdown links') {
             Markdown markdown = new Markdown(this, "3.11.0")
             markdown.check()
         }
@@ -61,7 +61,7 @@ node('docker') {
                                 make 'compile'
                             }
 
-                            stage('Unit Tests') {
+                            stage('Unit tests') {
                                 make 'unit-test'
                                 junit allowEmptyResults: true, testResults: 'target/unit-tests/*-tests.xml'
                             }
@@ -92,7 +92,7 @@ node('docker') {
             }
 
             def cessetupImageName
-            stage('Build & Push Image') {
+            stage('Build & push image') {
                 String setupVersion = makefile.getVersion()
                 cessetupImageName = k3d.buildAndPushToLocalRegistry("cloudogu/${repositoryName}", setupVersion)
             }
@@ -110,11 +110,11 @@ node('docker') {
                 k3d.configureComponentOperatorVersion("latest")
             }
 
-            stage('Install and Trigger Setup (trigger warning: setup)') {
+            stage('Install and trigger setup') {
                 k3d.helm("install -f k3d_values.yaml ${repositoryName} ${helmChartDir}")
             }
 
-            stage("wait for k8s-specific dogu (it has special needs)") {
+            stage("Wait for k8s-specific dogu") {
                 k3d.waitForDeploymentRollout("nginx-ingress", 300, 10)
             }
 

--- a/app/setup/data/createLoadBalancerStep.go
+++ b/app/setup/data/createLoadBalancerStep.go
@@ -45,7 +45,7 @@ func (fcs *createLoadBalancerStep) PerformSetupStep(ctx context.Context) error {
 		return err
 	}
 
-	return fcs.upsertServiceResource(ctx)
+	return fcs.upsertLoadbalancerService(ctx)
 }
 
 func (fcs *createLoadBalancerStep) checkIfNginxWillBeInstalled() error {
@@ -57,7 +57,7 @@ func (fcs *createLoadBalancerStep) checkIfNginxWillBeInstalled() error {
 	return fmt.Errorf("invalid configuration: FQDN can only be created if nginx-ingress will be installed")
 }
 
-func (fcs *createLoadBalancerStep) upsertServiceResource(ctx context.Context) error {
+func (fcs *createLoadBalancerStep) upsertLoadbalancerService(ctx context.Context) error {
 	ipSingleStackPolicy := corev1.IPFamilyPolicySingleStack
 	serviceResource := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/app/setup/data/createLoadBalancerStep.go
+++ b/app/setup/data/createLoadBalancerStep.go
@@ -74,9 +74,9 @@ func (fcs *createLoadBalancerStep) upsertServiceResource(ctx context.Context) er
 		},
 	}
 
-	get, err := fcs.clientSet.CoreV1().Services(fcs.namespace).Get(ctx, serviceResource.Name, metav1.GetOptions{})
+	actualService, err := fcs.clientSet.CoreV1().Services(fcs.namespace).Get(ctx, serviceResource.Name, metav1.GetOptions{})
 	if err == nil {
-		return fcs.updateServiceResource(ctx, get, serviceResource)
+		return fcs.updateServiceResource(ctx, actualService, serviceResource)
 	}
 
 	if err != nil && errors.IsNotFound(err) {

--- a/app/setup/data/createLoadBalancerStep.go
+++ b/app/setup/data/createLoadBalancerStep.go
@@ -3,11 +3,11 @@ package data
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"strings"
 
 	appcontext "github.com/cloudogu/k8s-ces-setup/app/context"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -45,7 +45,7 @@ func (fcs *createLoadBalancerStep) PerformSetupStep(ctx context.Context) error {
 		return err
 	}
 
-	return fcs.createServiceResource(ctx)
+	return fcs.upsertServiceResource(ctx)
 }
 
 func (fcs *createLoadBalancerStep) checkIfNginxWillBeInstalled() error {
@@ -57,7 +57,7 @@ func (fcs *createLoadBalancerStep) checkIfNginxWillBeInstalled() error {
 	return fmt.Errorf("invalid configuration: FQDN can only be created if nginx-ingress will be installed")
 }
 
-func (fcs *createLoadBalancerStep) createServiceResource(ctx context.Context) error {
+func (fcs *createLoadBalancerStep) upsertServiceResource(ctx context.Context) error {
 	ipSingleStackPolicy := corev1.IPFamilyPolicySingleStack
 	serviceResource := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -74,15 +74,34 @@ func (fcs *createLoadBalancerStep) createServiceResource(ctx context.Context) er
 		},
 	}
 
-	// Delete for idempotence
-	err := fcs.clientSet.CoreV1().Services(fcs.namespace).Delete(ctx, serviceResource.Name, metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
+	get, err := fcs.clientSet.CoreV1().Services(fcs.namespace).Get(ctx, serviceResource.Name, metav1.GetOptions{})
+	if err == nil {
+		return fcs.updateServiceResource(ctx, get, serviceResource)
 	}
 
-	logrus.Debug("Create load balancer service")
-	_, err = fcs.clientSet.CoreV1().Services(fcs.namespace).Create(ctx, serviceResource, metav1.CreateOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		logrus.Debug("Create load balancer service")
+		_, err = fcs.clientSet.CoreV1().Services(fcs.namespace).Create(ctx, serviceResource, metav1.CreateOptions{})
+	}
+
 	return err
+}
+
+func (fcs *createLoadBalancerStep) updateServiceResource(ctx context.Context, actualService *corev1.Service, service *corev1.Service) error {
+	logrus.Debug("Update existing load balancer service")
+	// Update to ensure idempotence
+	if actualService.Labels != nil {
+		actualService.Labels["app"] = "ces"
+	} else {
+		actualService.Labels = service.Labels
+	}
+	actualService.Spec.Type = service.Spec.Type
+	actualService.Spec.IPFamilyPolicy = service.Spec.IPFamilyPolicy
+	actualService.Spec.IPFamilies = service.Spec.IPFamilies
+	actualService.Spec.Selector = service.Spec.Selector
+	actualService.Spec.Ports = service.Spec.Ports
+	_, updateErr := fcs.clientSet.CoreV1().Services(fcs.namespace).Update(ctx, actualService, metav1.UpdateOptions{})
+	return updateErr
 }
 
 func createNginxPortResource(port int) corev1.ServicePort {
@@ -90,6 +109,6 @@ func createNginxPortResource(port int) corev1.ServicePort {
 		Name:       fmt.Sprintf("%s-%d", nginxIngressName, port),
 		Protocol:   corev1.ProtocolTCP,
 		Port:       int32(port),
-		TargetPort: intstr.FromInt(port),
+		TargetPort: intstr.FromInt32(int32(port)),
 	}
 }

--- a/app/setup/data/createLoadBalancerStep_test.go
+++ b/app/setup/data/createLoadBalancerStep_test.go
@@ -2,11 +2,13 @@ package data
 
 import (
 	"context"
+	"fmt"
 	appctx "github.com/cloudogu/k8s-ces-setup/app/context"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	"testing"
 )
@@ -16,7 +18,7 @@ var testCtx = context.Background()
 func Test_createLoadBalancerStep_PerformSetupStep(t *testing.T) {
 	t.Run("creates load-balancer if none exists", func(t *testing.T) {
 		// given
-		fakeClient := fake.NewSimpleClientset()
+		fakeClient := fake.NewClientset()
 		config := &appctx.SetupJsonConfiguration{Naming: appctx.Naming{Fqdn: ""}, Dogus: appctx.Dogus{Install: []string{nginxIngressName}}}
 		sut := NewCreateLoadBalancerStep(config, fakeClient, testNamespace)
 
@@ -41,7 +43,7 @@ func Test_createLoadBalancerStep_PerformSetupStep(t *testing.T) {
 			},
 			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
 		}
-		fakeClient := fake.NewSimpleClientset(serviceResource)
+		fakeClient := fake.NewClientset(serviceResource)
 		config := &appctx.SetupJsonConfiguration{Naming: appctx.Naming{Fqdn: ""}, Dogus: appctx.Dogus{Install: []string{nginxIngressName}}}
 		sut := NewCreateLoadBalancerStep(config, fakeClient, testNamespace)
 
@@ -56,5 +58,53 @@ func Test_createLoadBalancerStep_PerformSetupStep(t *testing.T) {
 		expected := map[string]string{"app": "ces"}
 		assert.Equal(t, expected, actual.ObjectMeta.Labels)
 		assert.Equal(t, corev1.ServiceTypeLoadBalancer, actual.Spec.Type)
+	})
+
+	t.Run("reuse existing loadbalancer with initial port mapping to keep current ip", func(t *testing.T) {
+		// given
+		expectedLabels := map[string]string{"app": "ces", "actual-ip": "1.2.3.4"}
+		serviceResource := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+
+				Name:      cesLoadbalancerName,
+				Labels:    expectedLabels,
+				Namespace: testNamespace,
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+		}
+		fakeClient := fake.NewClientset(serviceResource)
+		config := &appctx.SetupJsonConfiguration{Naming: appctx.Naming{Fqdn: ""}, Dogus: appctx.Dogus{Install: []string{nginxIngressName}}}
+		sut := NewCreateLoadBalancerStep(config, fakeClient, testNamespace)
+
+		// when
+		err := sut.PerformSetupStep(testCtx)
+
+		// then
+		require.NoError(t, err)
+		actual, err := fakeClient.CoreV1().Services(testNamespace).Get(testCtx, "ces-loadbalancer", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.NotNil(t, actual)
+		require.Equal(t, expectedLabels, actual.Labels)
+		assert.Equal(t, corev1.ServiceTypeLoadBalancer, actual.Spec.Type)
+		expectedIPSingleStackPolicy := corev1.IPFamilyPolicySingleStack
+		assert.Equal(t, &expectedIPSingleStackPolicy, actual.Spec.IPFamilyPolicy)
+		assert.Equal(t, []corev1.IPFamily{corev1.IPv4Protocol}, actual.Spec.IPFamilies)
+		assert.Equal(t, map[string]string{DoguLabelName: nginxIngressName}, actual.Spec.Selector)
+
+		expectedServicePorts := []corev1.ServicePort{
+			{
+				Name:       fmt.Sprintf("%s-%d", nginxIngressName, 80),
+				Protocol:   corev1.ProtocolTCP,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt32(80),
+			},
+			{
+				Name:       fmt.Sprintf("%s-%d", nginxIngressName, 443),
+				Protocol:   corev1.ProtocolTCP,
+				Port:       int32(443),
+				TargetPort: intstr.FromInt32(443),
+			},
+		}
+		assert.Equal(t, expectedServicePorts, actual.Spec.Ports)
 	})
 }


### PR DESCRIPTION
This is necessary for keycloak configurations where the ip must be available before the setup execution and can only be fetched from a service object.

Resolves #134