### PR TITLE
#130 Allow custom annotations for LoadBalancer service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#130] Add possibility to add custom annotations for `LoadBalancer` service.
 
 ## [v4.1.0] - 2025-07-16
 ### Fixed

--- a/app/context/setupJson.go
+++ b/app/context/setupJson.go
@@ -36,6 +36,8 @@ type Naming struct {
 	// InternalIp is useful if an external loadbalancer with its own IP is configured in front of the Cloudogu EcoSystem.
 	// It can be set to let dogus communicate directly within the Cloudogu EcoSystem without the detour over the load balancer.
 	InternalIp string `json:"internalIp"`
+	// Annotations for LoadBalancer Service
+	LoadBalancerAnnotations map[string]string `json:"loadBalancerAnnotations"`
 }
 
 // UserBackend contains configuration for the directory service.

--- a/app/setup/data/createLoadBalancerStep.go
+++ b/app/setup/data/createLoadBalancerStep.go
@@ -61,9 +61,10 @@ func (fcs *createLoadBalancerStep) upsertLoadbalancerService(ctx context.Context
 	ipSingleStackPolicy := corev1.IPFamilyPolicySingleStack
 	serviceResource := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cesLoadbalancerName,
-			Namespace: fcs.namespace,
-			Labels:    map[string]string{"app": "ces"},
+			Name:        cesLoadbalancerName,
+			Namespace:   fcs.namespace,
+			Labels:      map[string]string{"app": "ces"},
+			Annotations: fcs.config.Naming.LoadBalancerAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Type:           corev1.ServiceTypeLoadBalancer,


### PR DESCRIPTION
Hi,
I have added a simple way to add custom annotations to the generated LoadBalancer service. This may be a good approach to provide a generic method for static LoadBalancer IPs across different cloud provider implementations.